### PR TITLE
chore(doc): link to travis page

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -1,4 +1,4 @@
-= cbor-clj image:https://travis-ci.org/unithing/cbor-clj.svg?branch=master[title="Build Status"]
+= cbor-clj image:https://travis-ci.org/unithing/cbor-clj.svg?branch=master[title="Build Status", link="https://travis-ci.org/unithing/cbor-clj/"]
 
 :Author: Nico Rikken (NR), Erwin Kroon (EK)
 :Revision: 0


### PR DESCRIPTION
Just a small addition for easy linking to Travis CI.
